### PR TITLE
Fixes weekday-Display

### DIFF
--- a/frontend/lib/statistic_page.dart
+++ b/frontend/lib/statistic_page.dart
@@ -870,7 +870,7 @@ class StatisticPageState extends State<StatisticPage> {
   ///parses Strings to dates for month/Year display
   DateTime tryParseForCalendar(String dateString){
       try{
-        DateFormat("dd.MM.yyyy").parse(dateString);
+        return DateFormat("dd.MM.yyyy").parse(dateString);
       } catch(ex){
         //debugPrint("$ex");
       }


### PR DESCRIPTION
 - added an overlooked "return" when parsing weekday-name on statistic_page.dart